### PR TITLE
Update resume download requests

### DIFF
--- a/src/views/CreateResume.vue
+++ b/src/views/CreateResume.vue
@@ -243,27 +243,30 @@ export default {
      */
     handleCaptureAndSaveScreenshot() {
       // 获取当前简历ID
-      const resumeId = this.$route.params.resumeId;
+      const resumeId = this.$route.params.resumeId
 
-      // 发送请求获取简历信息
+      // 使用新的截图接口获取实时截图
       apiClient
-        .get(`/user/resumes/${resumeId}`)
+        .post('/pic/scf-screenshot', {
+          resumeId,
+          templateType: this.templateType,
+          color: this.color,
+        })
         .then((response) => {
-          if (response.data.code === 20003 && response.data.data.screenshotUrl) {
-            // 创建下载链接
-            const link = document.createElement('a');
-            link.href = response.data.data.screenshotUrl;
-            link.download = `${response.data.data.name || '简历'}.png`;
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
+          if (response.data.code === 20009 && response.data.data.screenshotUrl) {
+            const link = document.createElement('a')
+            link.href = response.data.data.screenshotUrl
+            link.download = `${response.data.data.resumeId}.png`
+            document.body.appendChild(link)
+            link.click()
+            document.body.removeChild(link)
           } else {
-            console.error('获取简历截图失败:', response.data.message);
+            console.error('获取简历截图失败:', response.data.message)
           }
         })
         .catch((error) => {
-          console.error('下载简历截图时出错:', error);
-        });
+          console.error('下载简历截图时出错:', error)
+        })
     },
     /**
      * 编辑某个标题

--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -527,20 +527,25 @@ export default {
         resume.showDropdown = false
       })
     },
-    downloadResume(resume) {
+    async downloadResume(resume) {
       try {
-        // 使用简历的截图链接
-        const imageUrl = resume.screenshotUrl || this.getResumeImage(resume)
+        const response = await apiClient.post('/pic/scf-screenshot', {
+          resumeId: resume.resumeId,
+          templateType: resume.templateType,
+          color: resume.color,
+        })
 
-        // 创建一个临时链接
-        const a = document.createElement('a')
-        a.href = imageUrl
-        a.download = `${resume.name || '简历'}.png`
-        document.body.appendChild(a)
-        a.click()
-        document.body.removeChild(a)
-
-        this.toast.success('简历下载中')
+        if (response.data.code === 20009 && response.data.data.screenshotUrl) {
+          const a = document.createElement('a')
+          a.href = response.data.data.screenshotUrl
+          a.download = `${resume.name || '简历'}.png`
+          document.body.appendChild(a)
+          a.click()
+          document.body.removeChild(a)
+          this.toast.success('简历下载中')
+        } else {
+          this.toast.error('下载失败，请重试')
+        }
       } catch (error) {
         console.error('下载失败:', error)
         this.toast.error('下载失败，请重试')


### PR DESCRIPTION
## Summary
- call new screenshot endpoint when downloading from home page
- call new screenshot endpoint in resume editor page

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*