### PR TITLE
Add loading state for resume download

### DIFF
--- a/src/components/BaseCVComponent.vue
+++ b/src/components/BaseCVComponent.vue
@@ -18,9 +18,15 @@
         <i class="fas fa-compress-alt"></i>
         <span class="button-text">智能一页</span>
       </button>
-      <button class="cv-top-button" @click="captureAndSaveScreenshot">
-        <i class="fas fa-download"></i>
-        <span class="button-text">下载</span>
+      <button
+        class="cv-top-button"
+        :class="{ 'loading-state': isDownloading }"
+        @click="captureAndSaveScreenshot"
+        :disabled="isDownloading"
+      >
+        <i v-if="!isDownloading" class="fas fa-download"></i>
+        <i v-else class="fas fa-spinner fa-spin"></i>
+        <span class="button-text">{{ isDownloading ? '下载中' : '下载' }}</span>
       </button>
     </div>
 
@@ -63,6 +69,10 @@ export default {
       default: ''
     },
     isPreview: {
+      type: Boolean,
+      default: false
+    },
+    isDownloading: {
       type: Boolean,
       default: false
     },
@@ -231,6 +241,16 @@ export default {
 .cv-top-button:hover {
   color: var(--color-primary-hover); /* Hover 时改变图标颜色 */
   background-color: rgba(0, 0, 0, 0.05); /* 轻微背景反馈 */
+}
+
+.cv-top-button.loading-state {
+  cursor: not-allowed;
+  color: #999;
+}
+
+.cv-top-button.loading-state:hover {
+  background-color: transparent;
+  color: #999;
 }
 
 .cv-top-button:hover .button-text {

--- a/src/views/CreateResume.vue
+++ b/src/views/CreateResume.vue
@@ -46,6 +46,7 @@
         :isNewTitle="isNewTitle"
         :color="color"
         :highlightTitle="currentSelectedTitle"
+        :isDownloading="isDownloading"
         @selected-module-changed="handleSelectedModuleChanged"
         @edit-title="handleEditTitle"
         @cancel-changes="handleCancelChanges"
@@ -82,6 +83,7 @@
               :isNewTitle="isNewTitle"
               :color="color"
               :highlightTitle="currentSelectedTitle"
+              :isDownloading="isDownloading"
               @selected-module-changed="handleSelectedModuleChanged"
               @edit-title="handleEditTitle"
               @cancel-changes="handleCancelChanges"
@@ -163,6 +165,7 @@ export default {
       // 新增的响应式/预览控制
       isMobile: false, // 是否是窄屏
       showPreview: false, // 是否展示“简历预览”弹窗
+      isDownloading: false, // 简历是否正在下载
     };
   },
   computed: {
@@ -242,6 +245,9 @@ export default {
      * 下载截图
      */
     handleCaptureAndSaveScreenshot() {
+      if (this.isDownloading) return
+      this.isDownloading = true
+
       // 获取当前简历ID
       const resumeId = this.$route.params.resumeId
 
@@ -266,6 +272,9 @@ export default {
         })
         .catch((error) => {
           console.error('下载简历截图时出错:', error)
+        })
+        .finally(() => {
+          this.isDownloading = false
         })
     },
     /**


### PR DESCRIPTION
## Summary
- show download spinner when capturing resume screenshot
- disable download button while saving screenshot

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*