### PR TITLE
Fix template closing tags in HomeLogged.vue

### DIFF
--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -51,9 +51,9 @@
               <i class="fas fa-file-alt"></i>
             </span>
             我的简历
-            <span class="resume-count" v-if="resumes.length > 0"
-              >{{ resumes.length }}</span
-            >
+          <span class="resume-count" v-if="resumes.length > 0">
+            {{ resumes.length }}
+          </span>
           </div>
           <div
             class="resume-tab"
@@ -64,9 +64,9 @@
               <i class="fas fa-trash-alt"></i>
             </span>
             回收站
-            <span class="resume-count" v-if="trashResumes.length > 0"
-              >{{ trashResumes.length }}</span
-            >
+          <span class="resume-count" v-if="trashResumes.length > 0">
+            {{ trashResumes.length }}
+          </span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- fix invalid closing `<span>` tags in HomeLogged.vue

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*