### PR TITLE
Update date picker to month-only

### DIFF
--- a/src/components/basic_ui/AppleStyleDatePicker.vue
+++ b/src/components/basic_ui/AppleStyleDatePicker.vue
@@ -5,7 +5,7 @@
   >
     <input
       :id="id"
-      type="date"
+      type="month"
       class="form-input"
       placeholder=" "
       :required="required"


### PR DESCRIPTION
## Summary
- limit `AppleStyleDatePicker` to pick year and month only

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*