### PR TITLE
Update screenshot endpoint usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "axios": "^1.7.9",
         "core-js": "^3.8.3",
+        "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
+        "jszip": "^3.10.1",
         "ldrs": "^1.0.2",
         "lunar-javascript": "^1.7.1",
         "vue": "^3.2.13",
@@ -4487,7 +4489,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -6295,6 +6296,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
@@ -7128,6 +7135,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -7171,7 +7184,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -7378,7 +7390,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -7555,6 +7566,48 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
@@ -7624,6 +7677,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -8744,6 +8806,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmmirror.com/param-case/-/param-case-3.0.4.tgz",
@@ -9593,7 +9661,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -10413,6 +10480,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11386,7 +11459,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "axios": "^1.7.9",
     "core-js": "^3.8.3",
+    "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
+    "jszip": "^3.10.1",
     "ldrs": "^1.0.2",
     "lunar-javascript": "^1.7.1",
     "vue": "^3.2.13",

--- a/src/views/CreateResume.vue
+++ b/src/views/CreateResume.vue
@@ -286,7 +286,18 @@ export default {
           color: this.color,
         })
         .then((response) => {
-          if (response.data.code === 20009 && response.data.data.screenshotUrl) {
+          const urls = response.data.data.screenshotUrls
+          if (response.data.code === 20009 && Array.isArray(urls) && urls.length) {
+            urls.forEach((url, index) => {
+              const link = document.createElement('a')
+              link.href = url
+              link.download = `${response.data.data.resumeId}_${index + 1}.png`
+              document.body.appendChild(link)
+              link.click()
+              document.body.removeChild(link)
+            })
+          } else if (response.data.data.screenshotUrl) {
+            // 向后兼容旧接口
             const link = document.createElement('a')
             link.href = response.data.data.screenshotUrl
             link.download = `${response.data.data.resumeId}.png`

--- a/src/views/CreateResume.vue
+++ b/src/views/CreateResume.vue
@@ -122,7 +122,6 @@ import apiClient from '@/api/axios';
 import { useToast } from 'vue-toastification';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
-import axios from 'axios';
 
 waveform.register();
 const chatgptInstance = ChatgptModel.getInstance();
@@ -327,7 +326,7 @@ export default {
       const zip = new JSZip()
       await Promise.all(
         urls.map((url, index) =>
-          axios.get(url, { responseType: 'blob' }).then((res) => {
+          apiClient.get(url, { responseType: 'blob' }).then((res) => {
             zip.file(`${baseName}_${index + 1}.png`, res.data)
           })
         )

--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -611,14 +611,25 @@ export default {
           color: resume.color,
         })
 
-        if (response.data.code === 20009 && response.data.data.screenshotUrl) {
+        const urls = response.data.data.screenshotUrls
+        if (response.data.code === 20009 && Array.isArray(urls) && urls.length) {
+          urls.forEach((url, index) => {
+            const a = document.createElement('a')
+            a.href = url
+            a.download = `${resume.name || '简历'}_${index + 1}.png`
+            document.body.appendChild(a)
+            a.click()
+            document.body.removeChild(a)
+          })
+        } else if (response.data.data.screenshotUrl) {
+          // 向后兼容旧接口
           const a = document.createElement('a')
           a.href = response.data.data.screenshotUrl
           a.download = `${resume.name || '简历'}.png`
           document.body.appendChild(a)
           a.click()
           document.body.removeChild(a)
-         } else {
+        } else {
           this.toast.error('下载失败，请重试')
         }
       } catch (error) {

--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -349,7 +349,6 @@ import { useToast } from 'vue-toastification'
 import { Solar } from 'lunar-javascript'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import axios from 'axios'
 
 // ====== 新增：导入简历弹窗组件 ======
 import ImportResumeModal from '@/components/ImportResumeModal.vue'
@@ -649,7 +648,7 @@ export default {
       const zip = new JSZip()
       await Promise.all(
         urls.map((url, index) =>
-          axios.get(url, { responseType: 'blob' }).then((res) => {
+          apiClient.get(url, { responseType: 'blob' }).then((res) => {
             zip.file(`${baseName}_${index + 1}.png`, res.data)
           })
         )


### PR DESCRIPTION
## Summary
- handle `/pic/scf-screenshot` multi-page results in `CreateResume.vue`
- support multi-page downloads in home page

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403954bad8832b9d1118f06f8b18d4