### PR TITLE
Use vue-sweetalert2 for nicer dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lunar-javascript": "^1.7.1",
         "vue": "^3.2.13",
         "vue-router": "^4.5.0",
+        "vue-sweetalert2": "^5.0.11",
         "vue-toastification": "^2.0.0-rc.5"
       },
       "devDependencies": {
@@ -11872,6 +11873,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/sweetalert2": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.4.4.tgz",
+      "integrity": "sha512-9yYWQuRT1v9JNI/paPTSYV+68MHwe9C+HQ/I2jtfaFzoJgYRftWXOs4JqmDSjT7m2m4r8ebMMn8LcxD1Wq9B/w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://sweetalert2.github.io/#donations"
+      }
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmmirror.com/table/-/table-6.9.0.tgz",
@@ -12604,6 +12614,18 @@
       "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-sweetalert2": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/vue-sweetalert2/-/vue-sweetalert2-5.0.11.tgz",
+      "integrity": "sha512-agujdlcNeLb4Fj0/V3qgR7bEVBN8IzWFoDBP/vrSgbEGl9pjMmxnv32V3lxB0SZtQh6tL6R/UZ+C3q8tzsJbNg==",
+      "license": "MIT",
+      "dependencies": {
+        "sweetalert2": "11.4.4"
+      },
+      "peerDependencies": {
+        "vue": "*"
+      }
     },
     "node_modules/vue-template-es2015-compiler": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lunar-javascript": "^1.7.1",
     "vue": "^3.2.13",
     "vue-router": "^4.5.0",
+    "vue-sweetalert2": "^5.0.11",
     "vue-toastification": "^2.0.0-rc.5"
   },
   "devDependencies": {

--- a/src/components/ImportResumeModal.vue
+++ b/src/components/ImportResumeModal.vue
@@ -218,7 +218,11 @@ export default {
       const ext = file.name.split('.').pop().toLowerCase()
 
       if (!validExtensions.includes(ext)) {
-        alert('文件类型不符合要求，请选择 PDF / DOC / DOCX / PNG。')
+        this.$swal({
+          icon: 'error',
+          title: '文件类型不符合要求',
+          text: '请选择 PDF / DOC / DOCX / PNG。'
+        })
         return
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,8 @@ import App from './App.vue'
 import router from './router'
 import Toast from "vue-toastification"
 import "vue-toastification/dist/index.css"
+import VueSweetalert2 from 'vue-sweetalert2'
+import 'sweetalert2/dist/sweetalert2.min.css'
 import './assets/global.css'
 import apiClient from './api/axios'
 
@@ -62,6 +64,7 @@ const toastOptions = {
   filterDuplicate: true
 }
 app.use(Toast, toastOptions)
+app.use(VueSweetalert2)
 
 // 挂载应用
 app.mount('#app')

--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -474,7 +474,14 @@ export default {
     },
 
     async deleteResume(resumeId) {
-      if (!confirm('确定要删除这个简历吗？')) return
+      const { isConfirmed } = await this.$swal({
+        icon: 'warning',
+        title: '确定要删除这个简历吗？',
+        showCancelButton: true,
+        confirmButtonText: '确定',
+        cancelButtonText: '取消'
+      })
+      if (!isConfirmed) return
 
       try {
         await apiClient.post(`/user/resumes/${resumeId}/recycle`)
@@ -521,7 +528,15 @@ export default {
     },
 
     async permanentDelete(resumeId) {
-      if (!confirm('确定要永久删除这个简历吗？此操作无法撤销')) return
+      const { isConfirmed } = await this.$swal({
+        icon: 'warning',
+        title: '确定要永久删除这个简历吗？',
+        text: '此操作无法撤销',
+        showCancelButton: true,
+        confirmButtonText: '确定',
+        cancelButtonText: '取消'
+      })
+      if (!isConfirmed) return
 
       try {
         await apiClient.delete(`/user/resumes/${resumeId}`)
@@ -731,7 +746,14 @@ export default {
     async batchDeleteMy() {
       if (this.selectedMy.length === 0) return
 
-      if (!confirm(`确定要删除选中的 ${this.selectedMy.length} 份简历吗？`)) return
+      const { isConfirmed } = await this.$swal({
+        icon: 'warning',
+        title: `确定要删除选中的 ${this.selectedMy.length} 份简历吗？`,
+        showCancelButton: true,
+        confirmButtonText: '确定',
+        cancelButtonText: '取消'
+      })
+      if (!isConfirmed) return
 
       try {
         await apiClient.post('/user/resumes-batch/recycle', {
@@ -764,8 +786,15 @@ export default {
     async batchDeleteTrash() {
       if (this.selectedTrash.length === 0) return
 
-      if (!confirm(`确定要永久删除选中的 ${this.selectedTrash.length} 份简历吗？此操作无法撤销`))
-        return
+      const { isConfirmed } = await this.$swal({
+        icon: 'warning',
+        title: `确定要永久删除选中的 ${this.selectedTrash.length} 份简历吗？`,
+        text: '此操作无法撤销',
+        showCancelButton: true,
+        confirmButtonText: '确定',
+        cancelButtonText: '取消'
+      })
+      if (!isConfirmed) return
 
       try {
         await apiClient.delete('/user/resumes-batch', {


### PR DESCRIPTION
## Summary
- add `vue-sweetalert2` dependency
- register the plugin in `src/main.js`
- use `$swal` for invalid file type warning in `ImportResumeModal`
- replace browser `confirm()` calls in `HomeLogged` with `$swal`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68440c8abd44832bacc475ccd524134d