### PR TITLE
Fix fake progress bar logic

### DIFF
--- a/src/views/TemplateSelection.vue
+++ b/src/views/TemplateSelection.vue
@@ -507,6 +507,7 @@ export default {
 
     startFakeProgress() {
       this.fakeProgress = 0;
+      let slowIncrementCounter = 0;
       if (this.progressTimer) {
         clearInterval(this.progressTimer);
       }
@@ -514,6 +515,12 @@ export default {
         if (this.fakeProgress < 95) {
           this.fakeProgress += Math.floor(Math.random() * 5) + 1;
           if (this.fakeProgress > 95) this.fakeProgress = 95;
+        } else if (this.fakeProgress < 100) {
+          slowIncrementCounter += 500;
+          if (slowIncrementCounter >= 3000) {
+            this.fakeProgress += 1;
+            slowIncrementCounter = 0;
+          }
         }
       }, 500);
     },


### PR DESCRIPTION
## Summary
- continue incrementing fake progress after 95%

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844375acc30832bbbf6697e4f919a0e