### PR TITLE
Fix logout dropdown alignment

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -562,9 +562,9 @@ export default {
 }
 
 .mobile-dropdown {
-  position: fixed;
-  top: 60px;
-  right: 20px;
+  position: absolute;
+  top: 100%;
+  right: 0;
 }
 
 .logged-in-menu {


### PR DESCRIPTION
## Summary
- keep mobile logout dropdown tied to avatar

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68443c84bf94832bb97d3ebc3879d997