### PR TITLE
Add multiline support to AppleStyleInput

### DIFF
--- a/src/components/EditTitleComponent.vue
+++ b/src/components/EditTitleComponent.vue
@@ -73,7 +73,7 @@
                         x
                     </button>
                 </div>
-                <AppleStyleInput :id="`bullet-combined-${index}`" labelText="要点" inputType="text" rows="2"
+                <AppleStyleInput :id="`bullet-combined-${index}`" labelText="要点" inputType="text" rows="3"
                     :required="true" v-model:modelValue="point.combined" />
             </div>
             <button class="add-button" type="button" @click="addBulletPoint">
@@ -107,7 +107,7 @@
                         x
                     </button>
                 </div>
-                <AppleStyleInput :id="`proj-bullet-${index}`" labelText="要点" inputType="text" rows="2" :required="true" v-model:modelValue="point.combined" />
+                <AppleStyleInput :id="`proj-bullet-${index}`" labelText="要点" inputType="text" rows="3" :required="true" v-model:modelValue="point.combined" />
             </div>
             <button class="add-button" type="button" @click="addBulletPoint">
                 + 新增Bullet Point

--- a/src/components/EditTitleComponent.vue
+++ b/src/components/EditTitleComponent.vue
@@ -73,7 +73,7 @@
                         x
                     </button>
                 </div>
-                <AppleStyleInput :id="`bullet-combined-${index}`" labelText="要点" inputType="text"
+                <AppleStyleInput :id="`bullet-combined-${index}`" labelText="要点" inputType="text" rows="2"
                     :required="true" v-model:modelValue="point.combined" />
             </div>
             <button class="add-button" type="button" @click="addBulletPoint">
@@ -107,7 +107,7 @@
                         x
                     </button>
                 </div>
-                <AppleStyleInput :id="`proj-bullet-${index}`" labelText="要点" inputType="text" :required="true" v-model:modelValue="point.combined" />
+                <AppleStyleInput :id="`proj-bullet-${index}`" labelText="要点" inputType="text" rows="2" :required="true" v-model:modelValue="point.combined" />
             </div>
             <button class="add-button" type="button" @click="addBulletPoint">
                 + 新增Bullet Point

--- a/src/components/basic_ui/AppleStyleInput.vue
+++ b/src/components/basic_ui/AppleStyleInput.vue
@@ -1,7 +1,7 @@
 <!-- ========== AppleStyleInput 组件 ========== -->
 <!-- src/components/basic_ui/AppleStyleInput.vue -->
 <template>
-  <div class="form-group" :style="{ height: rows * 50 + 'px' }">
+  <div class="form-group" :style="{ height: inputHeight }">
     <input
       v-if="rows === 1"
       :id="id"
@@ -70,7 +70,16 @@ export default {
       default: false
     }
   },
-  emits: ['update:modelValue']
+  emits: ['update:modelValue'],
+  computed: {
+    inputHeight() {
+      if (this.rows === 1) {
+        return '50px';
+      } else {
+        return this.rows * 24 + 'px';
+      }
+    }
+  }
 }
 </script>
 
@@ -96,7 +105,7 @@ export default {
 
 .textarea-input {
   overflow-y: auto;
-  resize: vertical;
+  resize: none; 
 }
 
 /* 当invalid=true时，边框变红色 */

--- a/src/components/basic_ui/AppleStyleInput.vue
+++ b/src/components/basic_ui/AppleStyleInput.vue
@@ -1,8 +1,9 @@
 <!-- ========== AppleStyleInput 组件 ========== -->
 <!-- src/components/basic_ui/AppleStyleInput.vue -->
 <template>
-  <div class="form-group">
+  <div class="form-group" :style="{ height: rows * 50 + 'px' }">
     <input
+      v-if="rows === 1"
       :id="id"
       :type="inputType"
       class="form-input"
@@ -11,6 +12,18 @@
       :required="required"
       :value="modelValue"
       :disabled="!enable"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+    <textarea
+      v-else
+      :id="id"
+      class="form-input textarea-input"
+      :class="{'error': invalid}"
+      :rows="rows"
+      placeholder=" "
+      :required="required"
+      :disabled="!enable"
+      :value="modelValue"
       @input="$emit('update:modelValue', $event.target.value)"
     />
     <label class="form-label" :for="id">{{ labelText }}</label>
@@ -45,6 +58,10 @@ export default {
       type: Boolean,
       default: true
     },
+    rows: {
+      type: Number,
+      default: 1
+    },
     /**
      * invalid: 是否标记为错误
      */
@@ -75,6 +92,11 @@ export default {
   display: block;
   background-color: white;
   transition: all 0.3s ease;
+}
+
+.textarea-input {
+  overflow-y: auto;
+  resize: vertical;
 }
 
 /* 当invalid=true时，边框变红色 */


### PR DESCRIPTION
## Summary
- update AppleStyleInput to support a rows prop
- use a textarea when rows > 1
- allow two-line bullet points in EditTitleComponent

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845064f0ee4832b999120ae4681af93