### PR TITLE
Add dropdown base component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -86,18 +86,21 @@
 
       <!-- 将底部元素包裹到一个容器中 -->
       <div class="bottom-section">
-        <div class="user-profile" @click="showMenu = !showMenu">
-          <img src="https://aicv-1307107697.cos.ap-guangzhou.myqcloud.com/asserts/icon/user-icon.svg" alt="user"
-            class="user-icon">
-          <div class="username mobile-username">{{ username }}</div>
-          <!-- 移动端下拉菜单 -->
-          <transition name="fade">
-            <ul v-show="showMenu" class="dropdown-menu">
+        <BaseDropdown v-model="showMenu">
+          <template #trigger>
+            <div class="user-profile" @click="showMenu = !showMenu">
+              <img src="https://aicv-1307107697.cos.ap-guangzhou.myqcloud.com/asserts/icon/user-icon.svg" alt="user"
+                class="user-icon">
+              <div class="username mobile-username">{{ username }}</div>
+            </div>
+          </template>
+          <template #menu>
+            <ul class="dropdown-menu">
               <li @click="handleSettings">设置</li>
               <li @click="handleLogout">退出登录</li>
             </ul>
-          </transition>
-        </div>
+          </template>
+        </BaseDropdown>
         <!-- 移动端菜单图标 -->
         <div class="mobile-menu-icon logged-in-menu" @click="toggleMobileMenu">
           <div class="menu-icon-bar" :class="{ 'menu-open': showMobileMenu }"></div>
@@ -114,9 +117,13 @@
 <script>
 import AuthService from '@/utils/auth'
 import { useToast } from 'vue-toastification'
+import BaseDropdown from '@/components/basic_ui/BaseDropdown.vue'
 
 export default {
   name: 'App',
+  components: {
+    BaseDropdown
+  },
   data() {
     return {
       showMenu: false,

--- a/src/components/basic_ui/BaseDropdown.vue
+++ b/src/components/basic_ui/BaseDropdown.vue
@@ -1,0 +1,59 @@
+<template>
+  <div ref="root" class="dropdown-wrapper" @click.stop>
+    <div class="dropdown-trigger">
+      <slot name="trigger"></slot>
+    </div>
+    <transition name="fade">
+      <div v-if="modelValue" class="dropdown-content">
+        <slot name="menu"></slot>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'BaseDropdown',
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  methods: {
+    close () {
+      this.$emit('update:modelValue', false)
+    },
+    onClickOutside (e) {
+      if (!this.$refs.root.contains(e.target)) {
+        this.close()
+      }
+    }
+  },
+  watch: {
+    modelValue (val) {
+      if (val) {
+        document.addEventListener('click', this.onClickOutside)
+      } else {
+        document.removeEventListener('click', this.onClickOutside)
+      }
+    }
+  },
+  mounted () {
+    if (this.modelValue) {
+      document.addEventListener('click', this.onClickOutside)
+    }
+  },
+  beforeUnmount () {
+    document.removeEventListener('click', this.onClickOutside)
+  }
+}
+</script>
+
+<style scoped>
+.dropdown-content {
+  position: absolute;
+  z-index: 10;
+}
+</style>

--- a/src/views/HomeLogged.vue
+++ b/src/views/HomeLogged.vue
@@ -85,24 +85,30 @@
                     {{ formatDate(resume.updatedAt || resume.createdAt) }}
                   </div>
                   <div class="resume-actions-dropdown" v-if="!selectModeMy">
-                    <div class="resume-dropdown-trigger" @click.stop="toggleDropdown(resume.resumeId)">
-                      <i class="fas fa-ellipsis-h"></i>
-                    </div>
-                    <div class="resume-dropdown-menu" v-if="resume.showDropdown">
-                      <div class="resume-dropdown-item" @click.stop="downloadResume(resume)"
-                        :class="{ disabled: resume.isDownloading }">
-                        <i v-if="!resume.isDownloading" class="fas fa-download"></i>
-                        <i v-else class="fas fa-spinner fa-spin"></i>
-                        {{ resume.isDownloading ? '下载中...' : '下载简历' }}
-                      </div>
-                      <div class="resume-dropdown-item resume-dropdown-item-delete"
-                        @click.stop="deleteResume(resume.resumeId)">
-                        <i class="fas fa-trash"></i> 删除简历
-                      </div>
-                      <div class="resume-dropdown-item" @click.stop="renameResume(resume)">
-                        <i class="fas fa-edit"></i> 修改名称
-                      </div>
-                    </div>
+                    <BaseDropdown v-model="resume.showDropdown">
+                      <template #trigger>
+                        <div class="resume-dropdown-trigger" @click.stop="toggleDropdown(resume.resumeId)">
+                          <i class="fas fa-ellipsis-h"></i>
+                        </div>
+                      </template>
+                      <template #menu>
+                        <div class="resume-dropdown-menu">
+                          <div class="resume-dropdown-item" @click.stop="downloadResume(resume)"
+                            :class="{ disabled: resume.isDownloading }">
+                            <i v-if="!resume.isDownloading" class="fas fa-download"></i>
+                            <i v-else class="fas fa-spinner fa-spin"></i>
+                            {{ resume.isDownloading ? '下载中...' : '下载简历' }}
+                          </div>
+                          <div class="resume-dropdown-item resume-dropdown-item-delete"
+                            @click.stop="deleteResume(resume.resumeId)">
+                            <i class="fas fa-trash"></i> 删除简历
+                          </div>
+                          <div class="resume-dropdown-item" @click.stop="renameResume(resume)">
+                            <i class="fas fa-edit"></i> 修改名称
+                          </div>
+                        </div>
+                      </template>
+                    </BaseDropdown>
                   </div>
                 </div>
                 <div class="resume-preview">
@@ -153,18 +159,24 @@
                     {{ formatDate(resume.updatedAt || resume.createdAt) }}
                   </div>
                   <div class="resume-actions-dropdown" v-if="!selectModeTrash">
-                    <div class="resume-dropdown-trigger" @click.stop="toggleTrashDropdown(resume.resumeId)">
-                      <i class="fas fa-ellipsis-h"></i>
-                    </div>
-                    <div class="resume-dropdown-menu" v-if="resume.showDropdown">
-                      <div class="resume-dropdown-item" @click.stop="restoreResume(resume.resumeId)">
-                        <i class="fas fa-undo"></i> 恢复简历
-                      </div>
-                      <div class="resume-dropdown-item resume-dropdown-item-delete"
-                        @click.stop="permanentDelete(resume.resumeId)">
-                        <i class="fas fa-trash"></i> 彻底删除
-                      </div>
-                    </div>
+                    <BaseDropdown v-model="resume.showDropdown">
+                      <template #trigger>
+                        <div class="resume-dropdown-trigger" @click.stop="toggleTrashDropdown(resume.resumeId)">
+                          <i class="fas fa-ellipsis-h"></i>
+                        </div>
+                      </template>
+                      <template #menu>
+                        <div class="resume-dropdown-menu">
+                          <div class="resume-dropdown-item" @click.stop="restoreResume(resume.resumeId)">
+                            <i class="fas fa-undo"></i> 恢复简历
+                          </div>
+                          <div class="resume-dropdown-item resume-dropdown-item-delete"
+                            @click.stop="permanentDelete(resume.resumeId)">
+                            <i class="fas fa-trash"></i> 彻底删除
+                          </div>
+                        </div>
+                      </template>
+                    </BaseDropdown>
                   </div>
                 </div>
                 <div class="resume-preview">
@@ -252,13 +264,15 @@ import { saveAs } from 'file-saver'
 
 // ====== 新增：导入简历弹窗组件 ======
 import ImportResumeModal from '@/components/ImportResumeModal.vue'
+import BaseDropdown from '@/components/basic_ui/BaseDropdown.vue'
 
 waveform.register()
 
 export default {
   name: 'HomeLogged',
   components: {
-    ImportResumeModal
+    ImportResumeModal,
+    BaseDropdown
   },
   data() {
     return {
@@ -583,9 +597,6 @@ export default {
       if (resume) {
         resume.showDropdown = !resume.showDropdown
       }
-
-      // 点击其他地方关闭下拉菜单
-      document.addEventListener('click', this.closeAllDropdowns, { once: true })
     },
     toggleTrashDropdown(resumeId) {
       // 关闭其他所有下拉菜单
@@ -600,19 +611,6 @@ export default {
       if (resume) {
         resume.showDropdown = !resume.showDropdown
       }
-
-      // 点击其他地方关闭下拉菜单
-      document.addEventListener('click', this.closeAllTrashDropdowns, { once: true })
-    },
-    closeAllDropdowns() {
-      this.resumes.forEach((resume) => {
-        resume.showDropdown = false
-      })
-    },
-    closeAllTrashDropdowns() {
-      this.trashResumes.forEach((resume) => {
-        resume.showDropdown = false
-      })
     },
     async downloadResume(resume) {
       if (resume.isDownloading) return


### PR DESCRIPTION
## Summary
- create BaseDropdown to encapsulate dropdown menu behavior
- use BaseDropdown for resume actions
- use BaseDropdown in the mobile header menu

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ada74b46c8327a0fdb6abaa33b58b