### PR TITLE
feat: convert settings page to dialog

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -69,9 +69,9 @@
           <router-link to="/dashboard" class="mobile-nav-item" @click="showMobileMenu = false">
             <span>我的简历</span>
           </router-link>
-          <router-link to="/settings" class="mobile-nav-item" @click="showMobileMenu = false">
+          <div class="mobile-nav-item" @click="handleSettings">
             <span>账户设置</span>
-          </router-link>
+          </div>
           <div class="mobile-nav-item" @click="handleLogout">退出登录</div>
         </template>
       </div>
@@ -111,6 +111,7 @@
     </header>
 
     <router-view class="router-view" />
+    <SettingsDialog v-if="showSettingsDialog" @close="showSettingsDialog = false" />
   </div>
 </template>
 
@@ -118,16 +119,19 @@
 import AuthService from '@/utils/auth'
 import { useToast } from 'vue-toastification'
 import BaseDropdown from '@/components/basic_ui/BaseDropdown.vue'
+import SettingsDialog from '@/components/SettingsDialog.vue'
 
 export default {
   name: 'App',
   components: {
-    BaseDropdown
+    BaseDropdown,
+    SettingsDialog
   },
   data() {
     return {
       showMenu: false,
-      showMobileMenu: false
+      showMobileMenu: false,
+      showSettingsDialog: false
     }
   },
   setup() {
@@ -157,7 +161,8 @@ export default {
     },
     handleSettings() {
       this.showMenu = false
-      this.$router.push('/settings')
+      this.showMobileMenu = false
+      this.showSettingsDialog = true
     },
     toggleMobileMenu() {
       this.showMobileMenu = !this.showMobileMenu

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -1,26 +1,30 @@
 <template>
-  <div class="modal-container">
-    <div class="modal-header">
-      <button class="close-btn" @click="closeDialog">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
-    </div>
-    <div class="tab-header">
-      <div :class="['tab-item', { active: activeTab === 'profile' }]" @click="selectTab('profile')">个人信息</div>
-      <div :class="['tab-item', { active: activeTab === 'legal' }]" @click="selectTab('legal')">隐私政策和服务协议</div>
-    </div>
-    <div class="tab-content">
-      <div v-if="activeTab === 'profile'">
-        <p>{{ contact }}</p>
+  <div class="modal-overlay" @click.self="closeDialog">
+    <transition name="fade-scale">
+      <div class="modal-container">
+        <div class="modal-header">
+          <button class="close-btn" @click="closeDialog">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+        <div class="tab-header">
+          <div :class="['tab-item', { active: activeTab === 'profile' }]" @click="selectTab('profile')">个人信息</div>
+          <div :class="['tab-item', { active: activeTab === 'legal' }]" @click="selectTab('legal')">隐私政策和服务协议</div>
+        </div>
+        <div class="tab-content">
+          <div v-if="activeTab === 'profile'">
+            <p>{{ contact }}</p>
+          </div>
+          <div v-else-if="activeTab === 'legal'" class="legal-links">
+            <router-link to="/privacy-policy" class="legal-link">隐私政策</router-link>
+            <router-link to="/service-agreement" class="legal-link">服务协议</router-link>
+          </div>
+        </div>
       </div>
-      <div v-else-if="activeTab === 'legal'" class="legal-links">
-        <router-link to="/privacy-policy" class="legal-link">隐私政策</router-link>
-        <router-link to="/service-agreement" class="legal-link">服务协议</router-link>
-      </div>
-    </div>
+    </transition>
   </div>
 </template>
 
@@ -28,23 +32,21 @@
 import AuthService from '@/utils/auth'
 
 export default {
-  name: 'SettingsPage',
+  name: 'SettingsDialog',
+  emits: ['close'],
   data() {
     return {
       activeTab: 'profile'
     }
   },
   computed: {
-    username() {
-      return AuthService.getCurrentUser()?.username || ''
-    },
     contact() {
       return AuthService.getUserContact()
     }
   },
   methods: {
     closeDialog() {
-      this.$router.back()
+      this.$emit('close')
     },
     selectTab(tab) {
       this.activeTab = tab
@@ -54,8 +56,9 @@ export default {
 </script>
 
 <style scoped>
+
 .modal-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   backdrop-filter: blur(8px);
   background-color: rgba(0, 0, 0, 0.5);
@@ -80,7 +83,8 @@ export default {
 
 .modal-container {
   background: var(--color-white);
-  max-width: calc(100% - 120px);
+  width: 480px;
+  max-width: 95%;
   border-radius: 20px;
   padding: 20px 28px 28px 28px;
   box-shadow: 0 15px 40px rgba(0, 0, 0, 0.18);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,7 +9,6 @@ import TemplateSelection from '@/views/TemplateSelection.vue'
 import AuthPage from '@/views/AuthPage.vue'
 import AuthSecondStepPage from '@/views/AuthSecondStepPage.vue'
 import InterviewQuestions from '@/views/InterviewQuestions.vue'
-import SettingsPage from '@/views/SettingsPage.vue'
 import PrivacyPolicy from '@/views/PrivacyPolicy.vue'
 import ServiceAgreement from '@/views/ServiceAgreement.vue'
 import WeChatCallback from '@/views/WeChatCallback.vue'
@@ -71,11 +70,6 @@ const routes = [
     name: 'AuthSecondStep',
     component: AuthSecondStepPage,
     props: true
-  },
-  {
-    path: '/settings',
-    name: 'Settings',
-    component: SettingsPage
   },
   {
     path: '/privacy-policy',


### PR DESCRIPTION
## Summary
- replace standalone settings page with reusable SettingsDialog component
- open settings dialog from navigation and remove router-based settings page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689857ab9c3c8327943e1cc968ed1fd0